### PR TITLE
Definition retrieval endpoint

### DIFF
--- a/data/semantic_groups.txt
+++ b/data/semantic_groups.txt
@@ -1,0 +1,31 @@
+Tissue
+Body Location or Region
+Sign or Symptom
+Body Part, Organ, or Organ Component
+Disease or Syndrome
+Congenital Abnormality
+Anatomical Abnormality
+Injury or Poisoning
+Pathologic Function
+Medical Device
+Laboratory or Test Result
+Organ or Tissue Function
+Physiologic Function
+Acquired Abnormality
+Body Space or Junction
+Clinical Drug 
+Anatomical Structure
+Cell or Molecular Dysfunction
+Biologic Function
+Health Care Activity
+Body Substance
+Antibiotic
+Functional Concept
+Embryonic Structure
+Therapeutic or Preventive Procedure
+Diagnostic Procedure
+Virus
+Laboratory Procedure
+Mental or Behavioral Dysfunction
+Experimental Model of Disease
+Body System

--- a/main.py
+++ b/main.py
@@ -10,3 +10,9 @@ def read_root():
 @app.get("/explain/{term}")
 def explain(term: str):
     return controller.explain(term)
+
+@app.get("/define/{term}")
+def define(term: str):
+    term_file = "data/term_to_cui.json"
+    def_file = "data/cui_to_def.json"
+    return controller.define(term, term_file, def_file)

--- a/main.py
+++ b/main.py
@@ -13,6 +13,4 @@ def explain(term: str):
 
 @app.get("/define/{term}")
 def define(term: str):
-    term_file = "data/term_to_cui.json"
-    def_file = "data/cui_to_def.json"
-    return controller.define(term, term_file, def_file)
+    return controller.define(term)

--- a/model/controller.py
+++ b/model/controller.py
@@ -4,5 +4,5 @@ from model.term_def_retrieval.retrieval import get_definition
 def explain(term: str) -> dict:
     return {"term": term}
 
-def define(term: str, term_file: str, def_file: str) -> dict:
-    return get_definition(term, term_file, def_file)
+def define(term: str) -> dict:
+    return get_definition(term)

--- a/model/controller.py
+++ b/model/controller.py
@@ -1,4 +1,8 @@
 import nltk
+from model.term_def_retrieval.retrieval import get_definition
 
 def explain(term: str) -> dict:
     return {"term": term}
+
+def define(term: str, term_file: str, def_file: str) -> dict:
+    return get_definition(term, term_file, def_file)

--- a/model/term_def_retrieval/retrieval.py
+++ b/model/term_def_retrieval/retrieval.py
@@ -1,0 +1,51 @@
+import json
+import os
+
+"""
+Notes for me:
+- Load JSON with each call
+- Each call retrieves a single term or definition
+- Function takes a str
+"""
+
+
+
+
+def get_definition(sample: str, term_to_cui_file: str = "../../data/term_to_cui.json", 
+                   cui_to_def_file: str = "../../data/cui_to_def.json") -> dict:
+    """
+    Retrieves potential definitions for a given term or phrase.
+
+    Currently only identifies jargon in the list based on exact match.
+    
+    Arguments:
+        sample (str): the term or phrase to look up in the jargon list and define.
+
+    Returns:
+        dict{source1: def1, source2: def2, ...}:
+            if sample appears in jargon list.
+        dict{}:
+            if sample is found but not defined.
+        None: 
+            if sample DOES NOT appear in jargon list.
+    """
+    sample_term = sample.lower().strip()
+    
+    # check if sample is in jargon list
+    with open(term_to_cui_file, 'r') as f:
+        term_to_cui = json.load(f)
+
+    if sample_term in term_to_cui.keys():
+        sample_cuis = term_to_cui[sample_term]   # list of all possible CUIs
+    else: 
+        return None   # sample not in jargon list:
+
+    # retrieve definitions for sample
+    with open(cui_to_def_file, 'r') as f:
+        cui_to_def = json.load(f)
+
+    for cui in sample_cuis:
+        # retrieve empty dictionary if not defined
+        definitions = cui_to_def.get(cui, {})
+
+    return definitions

--- a/model/term_def_retrieval/retrieval.py
+++ b/model/term_def_retrieval/retrieval.py
@@ -1,18 +1,20 @@
 import json
 import os
+from os.path import basename, dirname, join
 
-"""
-Notes for me:
-- Load JSON with each call
-- Each call retrieves a single term or definition
-- Function takes a str
-"""
+# SET GLOBAL VARIABLES: -----------------------------------
+# find root of repo:
+dir = os.getcwd()
+while basename(dir) != "med-jargon-explain-inator":
+    dir = dirname(dirname(dir))
 
+# get absolute paths to the data files:
+# NOTE: assumes that the data file structure will not change.
+term_to_cui_file = join(dir, "data/term_to_cui.json")
+cui_to_def_file = join (dir, "data/cui_to_def.json")
+# ---------------------------------------------------------
 
-
-
-def get_definition(sample: str, term_to_cui_file: str = "../../data/term_to_cui.json", 
-                   cui_to_def_file: str = "../../data/cui_to_def.json") -> dict:
+def get_definition(sample: str) -> dict:
     """
     Retrieves potential definitions for a given term or phrase.
 


### PR DESCRIPTION
`Main.py` and `controller.py` have been edited to retrieve a definition, given a term. 

Run the app from the repo root using `uvicorn main:app --reload`, then go to `http://127.0.0.1:8000/define/{term}`. (Fill in a term -- "humerus" for example). It will show the definition list in dictionary format. I opted to preserve the dictionary format for now, as opposed to converting to a list, so that we can continue to track the definition sources. **Let me know if we need list (not dict) format.**

The current behavior loads the term and definition JSONs each time the endpoint is called, as per the discussion Jon and I had on 5/20. This is something to look out for if it slows our app significantly once we have end-to-end functionality.

The expected outputs are:
A dictionary of format `{source1: def1, source2: def2, ...}`
- If the given term is defined in our dataset
An empty dictionary `{}`
- If the given term is in our jargon list but isn't defined
None
- If the given term is not in our jargon list

NOTE: This PR does not contain unit tests. I am hoping to start them after submitting this. :)

**Semantic Groupings**:
- This PR also adds a new file `semantic_groups.txt`, which is the list of semantic groups from UMLS that are included in our data (`term_to_cui.json`).