### PR TITLE
Identify jargon (NER)

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,12 @@ TBD, but you'll need at least Python 3.6. Install by using `pip <package name>`.
 - `nltk`
 - `fastapi`
 - `"uvicorn[standard]"`
+- `promptify`
+
+You will also need to run the command below with the correct python environment active. It downloads the dependency for NLTK's tokenizers:
+```shell
+python -m nltk.downloader punkt
+```
 
 ## Structure
 The explain-inator is built using a traditional [Model-View-Controller](https://www.geeksforgeeks.org/mvc-framework-introduction/) framework. See the READMEs inside each folder to see more details about how this all works together.

--- a/main.py
+++ b/main.py
@@ -14,3 +14,11 @@ def explain(term: str):
 @app.get("/define/{term}")
 def define(term: str):
     return controller.define(term)
+
+@ app.get("/identify/{text}")
+def identify(text: str):
+    return controller.identify(text)
+
+@ app.get("/identify_llm/{text}")
+def identify(text: str):
+    return controller.identify_llm(text)

--- a/model/controller.py
+++ b/model/controller.py
@@ -1,8 +1,15 @@
 import nltk
 from model.term_def_retrieval.retrieval import get_definition
+from model.jargon_identifier.ner import identify_jargon, identify_jargon_llm
 
 def explain(term: str) -> dict:
     return {"term": term}
 
 def define(term: str) -> dict:
     return get_definition(term)
+
+def identify(text: str) -> list[dict]:
+    return identify_jargon(text)
+
+def identify_llm(text: str) -> list[dict]:
+    return identify_jargon_llm(text)

--- a/model/jargon_identifer/ner.py
+++ b/model/jargon_identifer/ner.py
@@ -1,0 +1,142 @@
+# Recommended to test on Python 3.7+, openai 0.25+. Use `pip3 install promptify` before calling this script.
+# A short script for recongizing name entities using the promptify pipeline and LLM.
+
+import os
+from os.path import basename, dirname, join
+import json
+import regex as re
+from promptify import Prompter, OpenAI, Pipeline
+
+
+def get_app_root() -> str:
+    """
+    Finds the root of the app repo.
+
+    Assumes code is being run from the root or deeper in the file structure.
+
+    Returns:
+        str: the absolute path to the app root.
+    """
+    # find app root
+    dir = os.getcwd()
+    while basename(dir) != "med-jargon-explain-inator":
+        dir = dirname(dirname(dir))
+        
+    return dir
+
+
+def get_openai_key():
+    """
+    Finds and loads a .txt file containing the API user's OpenAI API key.
+
+    Expects API key to be in "med-jargon-explain-inator/openai-api-key.txt".
+    This file should contain one line with the key and no
+    other characters.
+
+    Returns:
+        api_key (str): the key to be used in OpenAI API calls
+    """
+    dir = get_app_root()
+
+    # read in API key from file
+    api_key_file = join(dir, "openai-api-key.txt")
+    with open(api_key_file, 'r') as f:
+        api_key = f.read()
+
+    return api_key
+
+
+def load_data(filename: str) -> dict:
+    """
+    Loads a data file (term-to-cui or cui-to-def).
+
+    Arguments:
+        filename (str): the name of the file (e.g., "term_to_cui_final.json")
+
+    Returns:
+        dict{}: the loaded file
+    """
+    dir = get_app_root()
+    data_file = join(dir, f"data/{filename}")
+    with open(data_file, 'r') as f:
+        data_dict = json.load(f)
+
+    return data_dict
+
+
+def get_term_indices(terms: list[str], text: str) -> list[dict]:
+    """
+    Identifies the location of term(s) in a given text.
+
+    Arguments:
+        terms (list[str]): A list of medical jargon in the text.
+        text (str): The text containing potential medical jargon.
+    
+    Returns:
+        list[dict{}, dict{}, ...]
+        Each dictionary represents an identified jargon phrase and contains 
+        the following keys:
+            - char_position_in_text (int): The index of the jargon's first 
+                character in the full text
+            - term_length (int): The full length of the jargon phrase (offset)
+
+        Generally, len(return_list) >= len(terms). A term seen more than once
+        in a text will be given multiple dictionaries to represent those
+        positions.
+    """
+    term_positions = []
+
+    # find each term in the text
+    for t in terms:
+        match_list = re.finditer(t, text, flags=re.IGNORECASE)
+        if match_list:
+            for match in match_list:
+                start, end = match.span()
+                length = end - start
+                term_positions.append({"char_position_in_text": start,
+                                       "term_length": length})
+                
+    return term_positions
+
+
+def identify_jargon(text: str) -> list[dict]:
+    """
+    Identifies medical jargon in a given text.
+
+    Given a text of any length (one or multiple sentences), this function
+    identifies the *locations* of potential medical jargon. Each term will
+    need to be sliced from the original text using the returned indices.
+
+    Arguments:
+        text (str): The text containing potential medical jargon.
+    
+    Returns:
+        list[dict{}, dict{}, ...]
+        Each dictionary represents an identified jargon phrase and contains 
+        the following keys:
+            - char_position_in_text (int): The index of the jargon's first 
+                character in the full text
+            - term_length (int): The full length of the jargon phrase (offset)
+    """
+    # get API key from file at root
+    api_key = get_openai_key()
+
+    # Input sentence for recognition - runs quickly w/ triple quotes (?)
+    sentence =  f"""{text}"""
+
+    # set up promptify model:
+    model = OpenAI(api_key)
+    prompter = Prompter('ner.jinja')
+    pipe = Pipeline(prompter , model)
+
+    # call promptify:
+    result = pipe.fit(sentence, domain="medical", labels=None)
+
+    # find jargon in model output:
+    completion = result[0]['parsed']['data']['completion']
+    terms = [term['E'] for term in completion if 'E' in term.keys()]
+
+    # find term indices in original text:
+    return get_term_indices(terms, text)
+
+print(identify_jargon("Test results returned positive for chronic emphesyma and an embolism."))

--- a/model/jargon_identifier/example_doc.txt
+++ b/model/jargon_identifier/example_doc.txt
@@ -1,0 +1,29 @@
+Your Care Instructions
+Cushing's syndrome is a rare hormonal problem. It happens when there is too much of the hormone cortisol in your body. It may be caused by using steroid medicine for a long time. Having tumours on the pituitary gland or adrenal glands can also cause it.
+
+The symptoms of Cushing's syndrome often appear slowly over time. They may include weight gain, skin changes (such as bruising, acne, or stretch marks), and muscle and bone weakness. The syndrome can also cause sex hormone changes. This can cause irregular periods and facial hair growth in women and erection problems in men.
+
+Treatment depends on the cause of the syndrome. If it's caused by steroid medicine, your doctor may change the amount of medicine you take. If it's caused by tumours on the pituitary or adrenal glands, your doctor may treat it with surgery, medicine, or radiation.
+
+Follow-up care is a key part of your treatment and safety. Be sure to make and go to all appointments, and call your doctor or nurse advice line (811 in most provinces and territories) if you are having problems. It's also a good idea to know your test results and keep a list of the medicines you take.
+
+How can you care for yourself at home?
+Eat a healthy diet that is high in protein and calcium. This can help prevent muscle and bone loss caused by the high cortisol levels in your body. Talk to your doctor about whether you should take a calcium and vitamin D supplement for bone health.
+Limit salt (sodium) in your diet. This is very important if you have high blood pressure because of Cushing's syndrome.
+Get exercise. Walking is a good choice to start with. Talk with your doctor about how much exercise is safe for you.
+Get regular eye exams to check for glaucoma and cataracts.
+See your doctor regularly to help diagnose and treat diabetes, high blood pressure, and other possible complications.
+When should you call for help?
+	
+Watch closely for changes in your health, and be sure to contact your doctor or nurse advice line if:
+
+You do not get better as expected.
+Your symptoms, such as weight gain or hair growth, are getting worse.
+For 24/7 nurse advice and general health information call Health Link at 811.
+
+Current as of: February 28, 2023
+
+Author: Healthwise Staff
+
+Clinical Review Board
+All Healthwise education is reviewed by a team that includes physicians, nurses, advanced practitioners, registered dieticians, and other healthcare professionals.

--- a/model/jargon_identifier/ner.py
+++ b/model/jargon_identifier/ner.py
@@ -1,5 +1,5 @@
 # Recommended to test on Python 3.7+, openai 0.25+. Use `pip3 install promptify` before calling this script.
-# A short script for recognizing name entities using the promptify pipeline and LLM.
+# Functions for recognizing medical jargon using the promptify LLM pipeline or using pure string processing.
 
 import os
 from os.path import basename, dirname, join
@@ -128,12 +128,10 @@ def identify_jargon_llm(text: str) -> list[dict]:
     # Input sentence for recognition - runs quickly w/ triple quotes (?)
     sentence =  f"""{text}"""
 
-    # set up promptify model:
+    # set up & call promptify model:
     model = OpenAI(api_key)
-    prompter = Prompter('ner.jinja')
+    prompter = Prompter('ner.jinja')    # only works with OpenAI models...
     pipe = Pipeline(prompter , model)
-
-    # call promptify:
     result = pipe.fit(sentence, domain="medical", labels=None)
 
     # find jargon in model output:
@@ -173,11 +171,11 @@ def identify_jargon(text: str) -> list[dict]:
     term_to_cui_dict = load_data("term_to_cui_final.json")
     recognized_term_list = [t.lower() for t in list(term_to_cui_dict.keys())]
 
-    # tokenize + lowercase (Ex: "Pulmonary embolism's a tough condition...")
+    # tokenize + lowercase
     tokens = [t.lower() for t in word_tokenize(text)]
     token_ct = len(tokens)
 
-    # run through text in slices, adding recognized jargon to list
+    # run through text in slices, add recognized jargon to list
     terms = []
 
     for idx in range(token_ct):
@@ -190,7 +188,7 @@ def identify_jargon(text: str) -> list[dict]:
                 if potential_term in recognized_term_list:
                     terms.append(potential_term)
 
-    return get_term_indices(terms, text)
+    return get_term_indices(set(terms), text)
 
 
 # # --------------------------------------------------------
@@ -202,7 +200,7 @@ def identify_jargon(text: str) -> list[dict]:
 #     text = f.read()
 
 # # Run & print each kind of jardon ID'er:
-# print(identify_jargon("she has asthma"))  # check that shorter sentences process.
+# print(identify_jargon("she has asthma."))  # check that shorter sentences process.
 # print(identify_jargon(sent))
 # print(identify_jargon(text))
 

--- a/model/jargon_identifier/ner.py
+++ b/model/jargon_identifier/ner.py
@@ -171,7 +171,7 @@ def identify_jargon(text: str) -> list[dict]:
     """
     # load our term dictionary
     term_to_cui_dict = load_data("term_to_cui_final.json")
-    recognized_term_list = term_to_cui_dict.keys()
+    recognized_term_list = [t.lower() for t in list(term_to_cui_dict.keys())]
 
     # tokenize + lowercase (Ex: "Pulmonary embolism's a tough condition...")
     tokens = [t.lower() for t in word_tokenize(text)]
@@ -180,6 +180,7 @@ def identify_jargon(text: str) -> list[dict]:
     # run through text in slices, adding recognized jargon to list
     terms = []
 
+    # TODO: Fix loop below so that it works on texts < 5 tokens long!
     # all of our terms are <=5 tokens long
     for idx in range(token_ct - 4):
         # look at phrases of length 1 - 5:
@@ -201,6 +202,7 @@ def identify_jargon(text: str) -> list[dict]:
 #     text = f.read()
 
 # # Run & print each kind of jardon ID'er:
+# print(identify_jargon("she has copd"))
 # print(identify_jargon(sent))
 # print(identify_jargon(text))
 

--- a/model/jargon_identifier/ner.py
+++ b/model/jargon_identifier/ner.py
@@ -180,15 +180,15 @@ def identify_jargon(text: str) -> list[dict]:
     # run through text in slices, adding recognized jargon to list
     terms = []
 
-    # TODO: Fix loop below so that it works on texts < 5 tokens long!
-    # all of our terms are <=5 tokens long
-    for idx in range(token_ct - 4):
+    for idx in range(token_ct):
         # look at phrases of length 1 - 5:
         for offset in range(1, 6):
-            potential_term = " ".join(tokens[idx:idx+offset])
-            # if the phrase is in our list, add it as "identified jargon":
-            if potential_term in recognized_term_list:
-                terms.append(potential_term)
+            # ensure offset doesn't extend past end of str
+            if (idx + offset) <= token_ct:
+                potential_term = " ".join(tokens[idx:idx+offset])
+                # if the phrase is in our list, add it as "identified jargon":
+                if potential_term in recognized_term_list:
+                    terms.append(potential_term)
 
     return get_term_indices(terms, text)
 
@@ -202,7 +202,7 @@ def identify_jargon(text: str) -> list[dict]:
 #     text = f.read()
 
 # # Run & print each kind of jardon ID'er:
-# print(identify_jargon("she has copd"))
+# print(identify_jargon("she has asthma"))  # check that shorter sentences process.
 # print(identify_jargon(sent))
 # print(identify_jargon(text))
 


### PR DESCRIPTION
Building upon Vicky's NER files. I couldn't figure out how to pull from her branch on the old repo, so I copied the `ner.py` file from her pull request.

**Created _2 methods_ for identifying jargon in a document:**
- `identify_jargon_llm()` - Based on Vicky's code using the Promptify package. This sends the document to OpenAI's GPT-3.5 with an NER template tailored to medical jargon recognition.
  - Requires the API user to put an OpenAI API key in `med-jargon-explain-inator/openai-api-key.txt`
  - Promptify's ner.jinja template works extremely well, but it _only_ works with OpenAI models. This is a bit of a **data privacy concern**, given the expected use-case of this API, so I implemented another method, described below.
  - Sometimes hangs (probably because it's generating bad JSONs).
- `identify_jargon()` - Looks for exact matches between the text and our term list in `term_to_cui_final.json`. Uses pure python string processing and NLTK's tokenizer.
  - **Not as effective.** Our term list has a lot of stopwords and non-medical jargon.
  - If you compare each function's output on the example care instructions in `model/jargon_identifier/example_doc.txt`, you can see how our list affects the quality of `identify_jargon`'s output.
  - BUT ! Doesn't send sensitive medical information to a third-party. 

This new script `model/jargon_identifier/ner.py` uses similar file access as `retrieval.py` by locating the absolute path to the root from the current working directory, then finding the relevant file.

Added API endpoints to `main.py` and `model/controller.py`, one for either function listed above. After running `uvicorn main:app --reload`, navigate to:
- `http://127.0.0.1:8000/identify_llm/{text}` to use `identify_jargon_llm()`
- `http://127.0.0.1:8000/identify/{text}` to use `identify_jargon()`

Updated root README to reflect new packages.